### PR TITLE
skip android notification payload

### DIFF
--- a/lib/rpush/client/active_model/fcm/notification.rb
+++ b/lib/rpush/client/active_model/fcm/notification.rb
@@ -86,6 +86,9 @@ module Rpush
           end
 
           def android_notification
+            return {}
+            # currently our Android App is not able to deserialize this data
+            # if we omit it, the notification will display, otherwise it will not
             json = notification&.slice(*ANDROID_NOTIFICATION_KEYS) || {}
             json['notification_priority'] = priority_for_notification if priority
             json['sound'] = sound if sound


### PR DESCRIPTION
According to Firebase Docs (https://firebase.google.com/docs/reference/fcm/rest/v1/projects.messages#AndroidNotification) the included payload is correct. 
But our Social Android App seems unable to deserialize it, if it gets included...